### PR TITLE
feat(option): add `bCloseMenu` option

### DIFF
--- a/SRC/config.cpp
+++ b/SRC/config.cpp
@@ -6,6 +6,7 @@
 namespace config {
     const char* INI_FILE_NAME = "UAPNG.ini";
     int iMovementType;
+    bool bEnableCloseMenu;
     bool bEnableNotifications;
 
     std::string GetIniFilePath() {
@@ -30,6 +31,7 @@ namespace config {
     std::unordered_map<std::string, int> ReadSettings() {
         std::unordered_map<std::string, int> settings;
         settings["iMovementType"] = GetIniSetting("iMovementType", 0);
+        settings["bEnableCloseMenu"] = GetIniSetting("bEnableCloseMenu", 1);
         settings["bEnableNotifications"] = GetIniSetting("bEnableNotifications", 1);
         return settings;
     }

--- a/SRC/equip_object_override.cpp
+++ b/SRC/equip_object_override.cpp
@@ -1,4 +1,5 @@
 #include "actor_data.h"
+#include "config.h"
 #include "equip_object_override.h"
 #include "function_library.h"
 #include "logger.h"
@@ -19,7 +20,9 @@ void EquipObjectOverRide::thunk(RE::ActorEquipManager* a_self, RE::Actor* a_acto
             data.bAnimationInProgress = true;
             AnimObjectReplaceModelByFormID(0x0D36C8, AlchObjectGetModelPath(a_object).c_str());
             EquipPotion(a_actor, a_self, a_object, a_unk);
-            CloseMenu();
+            if (config::bEnableCloseMenu) {
+                CloseMenu();
+            }
 
             lastEquippedObject = a_object;
 

--- a/SRC/header_files/config.h
+++ b/SRC/header_files/config.h
@@ -3,6 +3,7 @@
 namespace config {
     extern const char* INI_FILE_NAME;
     extern int iMovementType;
+    extern bool bEnableCloseMenu;
     extern bool bEnableNotifications;
 
     std::string GetIniFilePath();

--- a/SRC/plugin.cpp
+++ b/SRC/plugin.cpp
@@ -20,6 +20,7 @@ SKSEPluginLoad(const SKSE::LoadInterface* skse) {
     SetupLog();
     auto settings = config::ReadSettings();
     config::iMovementType = settings["iMovementType"];
+    config::bEnableCloseMenu = settings["bEnableCloseMenu"] != 0;
     config::bEnableNotifications = settings["bEnableNotifications"] != 0;
     SKSE::GetMessagingInterface()->RegisterListener(PluginReady);
     return true;


### PR DESCRIPTION
I would like to choose whether or not to close my inventory when I drink a potion.

This dll was confirmed to work in test play.
Here are my settings when I ran the test.

- SKSE/Plugins/UAPNG.ini

```ini
[Settings]

###############################################################################################################################
#
#  Determine actor movement mode while drinking potion.
#  0 = RUN, 1 = WALK, 2 = LOCKED
#  Default = 0 
#       
###############################################################################################################################

iMovementType=1

###############################################################################################################################
#
#  Enable close menu when potion is currently being used.
#  Default = 1
#       
###############################################################################################################################

bEnableCloseMenu=1

###############################################################################################################################
#
#  Enable notifications when potion is currently being used.
#  Default = 1
#  Note: Requires bEnablePotionQueue to be set to 0
#       
###############################################################################################################################

bEnableNotifications=1
```