### PR TITLE
Feature/implement build ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
         # continue-on-error: true
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Utlimate Animated Potion NG - SKSE Plugin
           path: ${{ github.workspace }}/build/Release/UAPNG.dll

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,51 @@
+name: Build
+
+on: push
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [windows-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install latest CMake & Ninja
+        uses: lukka/get-cmake@latest
+
+      - name: vcpkg build
+        id: vcpkg
+        uses: johnwason/vcpkg-action@v5
+        with:
+          manifest-dir: ${{ github.workspace }} # Set to directory containing vcpkg.json
+          # Project is a dynamic link, but dependent libraries are statically linked.
+          # However, this setting is also set by cmake preset, so those specified here are currently meaningless.
+          # Entering this information because it is a required field to use this CI.
+          triplet: x64-windows-static-md
+          token: ${{ github.token }}
+
+      - name: Set up cmake-build cache
+        uses: actions/cache@v3
+        with:
+          path: ./build
+          key: cmake-build-${{ runner.os }}-${{ hashFiles('./CMakeLists.txt') }}
+          restore-keys: cmake-build.${{ runner.os }}.
+
+      # GitHub Action does not follow the path of cl.exe, which causes a path error, but this is to be avoided.
+      # See https://github.com/actions/runner-images/issues/6205#issuecomment-1241573412
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Build
+        run: |
+          cmake --preset release
+          cmake --build --preset verbose-build-windows -j $Env:NUMBER_OF_PROCESSORS
+        # Enable this to avoid wasting the cache of dependent libraries in case of frequent errors during development.
+        # continue-on-error: true
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Utlimate Animated Potion NG - SKSE Plugin
+          path: ${{ github.workspace }}/build/Release/UAPNG.dll

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,5 +30,13 @@
             "displayName": "Release",
             "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
         }
+    ],
+    "buildPresets": [
+        {
+            "name": "verbose-build-windows",
+            "displayName": "Verbose Build",
+            "configurePreset": "release",
+            "nativeToolOptions": ["-v"]
+        }
     ]
 }


### PR DESCRIPTION
Use GitHub CI for build reproducibility.

# Examples

- When there is no cache (e.g. first time build)
[build (windows-latest)](https://github.com/SARDONYX-forks/SKSE_UAPNG/actions/runs/7257553740/job/19771551050#logs)
succeeded 7 minutes ago in 24m 30s

- With cache (second build)
[build (windows-latest)](https://github.com/SARDONYX-forks/SKSE_UAPNG/actions/runs/7257768527/job/19772059598#logs)
succeeded 1 minute ago in 2m 36s
